### PR TITLE
Clean up the specs

### DIFF
--- a/spec/boolean.md
+++ b/spec/boolean.md
@@ -1,15 +1,26 @@
 # Booleans
 
-Taken from all inspiration languages excluding C and C++.
+From all inspiration languages except C(++).
 
-Documentation:
+## Semantics
+
 Computer science often deals with the concept of booleans - a value that is either true or false.
-PyHP++# also contains this type - True will be false and False will be true.
+PyHP++# also contains this type - `True` will be logically false and `False` will be logically true.
 
-For example:
+## Examples
+
+Here is an example of basic logic (assuming `||` is logical or and `&&` is logical and):
+
 ```
-if ($self->AwareOfIncompetence() == True)
-    {
-        return;
-    }
+returnsFalse() || (returnsTrue() && returnsTrue())
 ```
+
+This expression would evaluate to `False`, because `returnsFalse()` returns `False`, which is true. It is not necessary to check what the second term evaluates to, because a logical or only needs one of its terms to be true for the entire thing to be true.
+
+Here's another example:
+
+```
+returnsTrue() && returnsFalse()
+```
+
+In this case, the result is `True`, because `returnsTrue()` returns `True`, which is false. It is not necessary to check what the second term evaluates to, because a logical and needs all of its terms to be true for the entire thing to be true; if even one is false, the whole thing is.

--- a/spec/boolean.md
+++ b/spec/boolean.md
@@ -2,10 +2,13 @@
 
 From all inspiration languages except C(++).
 
-## Semantics
+## Rationale
 
 Computer science often deals with the concept of booleans - a value that is either true or false.
-PyHP++# also contains this type - `True` will be logically false and `False` will be logically true.
+
+## Syntax and semantics
+
+There SHALL be a type `boolean`. `True` SHALL be logically false and `False` SHALL be logically true.
 
 ## Examples
 

--- a/spec/if.md
+++ b/spec/if.md
@@ -1,20 +1,22 @@
 # If Statements
 
-Taken from JS and C++.
+From C++.
 
-## Documentation:
+## Syntax
 
-If statements will execute the code contained within the curly brackets {} if the expression within the brackets ()
-evaluates to the boolean value True (the logical false).
+If statements will execute the code contained within the following block if the expression within the `()` brackets evaluates to the boolean value `True` (logical false).
 
-An example of an if statement would be as follows:
+## Example
+
+In the case of the Original Example Code:
+
 ```
 if ($self->AwareOfIncompetence() == True)
   {
     return;
   }
 ```
-We can see clearly that, if the statement $self->AwareOfIncompetence() evaluates to True,
-then the statement $self->AwareOfIncompetence() == True would also evaluate to True and the code return;
-would be executed. In the event that $self->AwareOfIncompetence() == True evaluates to something other than true,
-no code in this snippet would be executed.
+
+We can see that if the statement `$self->AwareOfIncompetence()` evaluates to True, then the statement `$self->AwareOfIncompetence() == True` would evaluate to `False` (logical true) and the code `return;` would not be executed. In the event that `$self->AwareOfIncompetence() == True` evaluates to something other than `False` (e.g. `True`), `return;` would be executed.
+
+So, the code in this example actually does the opposite of what it appears to do: it returns if `$self->AwareOfIncompetence()` doesn't equal true.

--- a/spec/if.md
+++ b/spec/if.md
@@ -4,7 +4,7 @@ From C++.
 
 ## Syntax
 
-If statements will execute the code contained within the following block if the expression within the `()` brackets evaluates to the boolean value `True` (logical false).
+There SHALL be a statement `if`. `if` statements SHALL execute the code contained within the following block if and only if the expression within the `()` brackets evaluates to `True` (logical false).
 
 ## Example
 

--- a/spec/indentation.md
+++ b/spec/indentation.md
@@ -4,7 +4,7 @@ From Python
 
 ## Syntax
 
-After the start of a bracket-denoted block (square, curly or regular), lines must be indented from said brackets by whitespace in the form of a fixed, consistent number of tabs or spaces, until the end of the block. The brackets denoting the beginnings and ends of blocks must also be indented, if they are on their own lines. One line of code can, obviously, be indented multiple times.
+After the start of a bracket-denoted block (square, curly or regular), lines MUST be indented from said brackets by whitespace in the form of a fixed, consistent number of tabs or spaces, until the end of the block. The brackets denoting the beginnings and ends of blocks MUST also be indented, if they are on their own lines. One line of code can, obviously, be indented multiple times.
 
 ## Example
 

--- a/spec/template.md
+++ b/spec/template.md
@@ -1,40 +1,51 @@
 # Template Language
 
-This is a potential specification meta-programming template language, as suggested by /u/alexbuzzbee.
-It is designed to be highly versatile, and therefor contains many concepts from traditional programming languages.
-It is inspired by FORTH, erlang and, of course, the C++ templates.
+This is a potential specification meta-programming template language, as suggested by /u/alexbuzzbee. It is designed to be highly versatile, and therefore contains many concepts from traditional programming languages. It is inspired by FORTH, erlang and, of course, C++ templates.
 
-## Basic Syntax
+## Syntax
 
 The basic syntax will consist of a tag surrounded by angle brackets.
+
 ```
 command ::= "<" + tag + ">
 ```
 
-A tag must be any ascii string without whitespace.
-Execution
+A tag is be any ascii string without whitespace.
 
-Execution will occur at compile time, before most other attempts to parse the actual content.
-When a command is encountered, it's tag is compared to a list of action-tags. If the tag is an action-tag, the compiler will preform the associated action.
-If the tag is not an executor, the tag is pushed onto a stack.
+## Execution
 
-A list of substitutions is maintained. When a tag is popped from the stack for any reason, it is implicitly run threw this list of substitutions.
+Execution occurs at compile time, before most other attempts to parse the actual content.
+When a tag is encountered, its content is compared to a list of action tags. If the tag is an action tag, the compiler will perform the associated action. If the tag is not an action tag, the tag is pushed onto a stack.
 
-## List of default execution tags
+A list of substitutions is maintained. When a tag is popped from the stack for any reason, it is implicitly run through this list of substitutions.
 
-(We should append to this list as the specification grows. Also these names make way to much sense.)
+## List of default action tags
 
-`.` pops a tag from the stack and puts it at the current commands value in the program.
+(We should add to this list as the specification grows. Also these names make way to much sense.)
 
-`^` pops two(2) tags from the stack (source, destination) and creates a substitution from source to destination.
+`.` pops a tag from the stack and is replaced with its contents.
 
-`if` pops two tags from the stack (condition, value) and puts value if condition is truthy.
+`^` pops two (2) tags from the stack (`trigger`, `result`) and creates a substitution from `trigger` to `result`.
 
-`ifn` pops two tags from the stack (condition, value) and puts value if condition is falsey.
+`if` pops two tags from the stack (`condition`, `value`) and is replaced with `value`'s contents if `condition` is truthy.
 
-`+` pops two tags from the stack (a,b), courses them to numbers, and adds them, pushing the final value onto the stack.
+`ifn` pops two tags from the stack (`condition`, `value`) and is replaced with `value`'s contents if `condition` is falsey.
+
+`+` pops two tags from the stack (`a`, `b`), converts them to numbers, and adds them, pushing the final value onto the stack.
+
+## Truthy and falsey values
+
+All values are truthy except the following, which are falsey:
+
+- `no`
+- `false`
+- `0`
+- An empty tag
+- The bottom of the stack
 
 ## Example
+
+Here is an example:
 
 ```
 <yes>
@@ -52,4 +63,10 @@ A list of substitutions is maintained. When a tag is popped from the stack for a
 <if>
 ```
 
-will output `2`
+The final output of this is:
+
+```
+
+
+2
+```

--- a/spec/template.md
+++ b/spec/template.md
@@ -4,34 +4,33 @@ This is a potential specification meta-programming template language, as suggest
 
 ## Syntax
 
-The basic syntax will consist of a tag surrounded by angle brackets.
+The basic syntax SHALL consist of a tag surrounded by angle brackets:
 
 ```
 command ::= "<" + tag + ">
 ```
 
-A tag is be any ascii string without whitespace.
+A tag MAY be any ascii string without whitespace.
 
 ## Execution
 
-Execution occurs at compile time, before most other attempts to parse the actual content.
-When a tag is encountered, its content is compared to a list of action tags. If the tag is an action tag, the compiler will perform the associated action. If the tag is not an action tag, the tag is pushed onto a stack.
+Execution SHALL occur at compile time, before other attempts to parse the source file. When a tag is encountered, its content SHALL be compared to a list of action tags. If the tag is an action tag, the compiler SHALL perform the associated action. If the tag is not an action tag, the tag SHALL be pushed onto a stack.
 
-A list of substitutions is maintained. When a tag is popped from the stack for any reason, it is implicitly run through this list of substitutions.
+A list of substitutions SHALL be maintained. When a tag is popped from the stack for any reason, it SHALL be implicitly run through this list of substitutions.
 
 ## List of default action tags
 
 (We should add to this list as the specification grows. Also these names make way to much sense.)
 
-`.` pops a tag from the stack and is replaced with its contents.
+`.` SHALL pop a tag from the stack and be replaced with its contents.
 
-`^` pops two (2) tags from the stack (`trigger`, `result`) and creates a substitution from `trigger` to `result`.
+`^` SHALL pop two (2) tags from the stack (`trigger`, `result`) and create a substitution from `trigger` to `result`.
 
-`if` pops two tags from the stack (`condition`, `value`) and is replaced with `value`'s contents if `condition` is truthy.
+`if` SHALL pop two tags from the stack (`condition`, `value`) and be replaced with `value`'s contents if and only if `condition` is truthy. If `condition` is falsey, the `if` tag SHALL be deleted.
 
-`ifn` pops two tags from the stack (`condition`, `value`) and is replaced with `value`'s contents if `condition` is falsey.
+`ifn` SHALL pop two tags from the stack (`condition`, `value`) and be replaced with `value`'s contents if `condition` is falsey. If `condition` is truthy, the `ifn` tag SHALL be deleted.
 
-`+` pops two tags from the stack (`a`, `b`), converts them to numbers, and adds them, pushing the final value onto the stack.
+`+` SHALL pop two tags from the stack (`a`, `b`), convert them to numbers, and add them, pushing the final value onto the stack.
 
 ## Truthy and falsey values
 


### PR DESCRIPTION
I've made the specs more consistent and more clear, and I've also proofread them.

I think I've managed not to change the meaning of any of the specs more than absolutely necessary to make them consistant.

`<rant>`

I think `if` and logic operations should treat the same things as true and false. I'm fine with `True` being false and vice versa (even if it's not really in line with any of our inspiration languages, even if we do throw in JavaScript), but conditionals and logic operations should be consistant with each other. The goal is to make a horrible *combination* of Python, PHP, C++, and C#, not a horrible language that happens to have bits from those languages.

`</rant>`